### PR TITLE
Make custom status indicators Zenoss 4 compatible.

### DIFF
--- a/ZenPacks/zenoss/CheckPointMonitor/libexec/check_checkPointHaState.py
+++ b/ZenPacks/zenoss/CheckPointMonitor/libexec/check_checkPointHaState.py
@@ -35,7 +35,7 @@ class CheckPointHaStatePlugin(EasySnmpPlugin):
         elif state == "not active":
             print "HA is not active"
             exitStatus = 1
-        elif state == "stand-by":
+        elif state in ("standby", "stand-by"):
             print "HA is in stand-by"
         else:
             print "unknown HA state"

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.zenoss.CheckPointMonitor"
-VERSION = "1.0.6dev"
+VERSION = "2.0.0dev"
 AUTHOR = "Zenoss"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.CheckPointMonitor']
 INSTALL_REQUIRES = []
-COMPAT_ZENOSS_VERS = ">=2.4"
+COMPAT_ZENOSS_VERS = ">=4.0"
 PREV_ZENPACK_NAME = ""
 # STOP_REPLACEMENTS
 ################################
@@ -21,34 +21,34 @@ setup(
     # This ZenPack metadata should usually be edited with the Zenoss
     # ZenPack edit page.  Whenever the edit page is submitted it will
     # overwrite the values below (the ones it knows about) with new values.
-    name = NAME,
-    version = VERSION,
-    author = AUTHOR,
-    license = LICENSE,
-    
+    name=NAME,
+    version=VERSION,
+    author=AUTHOR,
+    license=LICENSE,
+
     # This is the version spec which indicates what versions of Zenoss
     # this ZenPack is compatible with
-    compatZenossVers = COMPAT_ZENOSS_VERS,
-    
+    compatZenossVers=COMPAT_ZENOSS_VERS,
+
     # previousZenPackName is a facility for telling Zenoss that the name
     # of this ZenPack has changed.  If no ZenPack with the current name is
     # installed then a zenpack of this name if installed will be upgraded.
-    prevZenPackName = PREV_ZENPACK_NAME, 
-    
+    prevZenPackName=PREV_ZENPACK_NAME,
+
     # Indicate to setuptools which namespace packages the zenpack
     # participates in
-    namespace_packages = NAMESPACE_PACKAGES,
-    
+    namespace_packages=NAMESPACE_PACKAGES,
+
     # Tell setuptools what packages this zenpack provides.
-    packages = find_packages(),
-    
+    packages=find_packages(),
+
     # Tell setuptools to figure out for itself which files to include
     # in the binary egg when it is built.
-    include_package_data = True,
-    
+    include_package_data=True,
+
     # The MANIFEST.in file is the recommended way of including additional files
     # in your ZenPack. package_data is another.
-    #package_data = {}
+    # package_data={}
 
     # Indicate dependencies on other python modules or ZenPacks.  This line
     # is modified by zenoss when the ZenPack edit page is submitted.  Zenoss
@@ -56,14 +56,14 @@ setup(
     # list, so any manual additions should be added to the end.  Things will
     # go poorly if this line is broken into multiple lines or modified to
     # dramatically.
-    install_requires = INSTALL_REQUIRES,
+    install_requires=INSTALL_REQUIRES,
 
     # Every ZenPack egg must define exactly one zenoss.zenpacks entry point
     # of this form.
-    entry_points = {
+    entry_points={
         'zenoss.zenpacks': '%s = %s' % (NAME, NAME),
     },
 
     # All ZenPack eggs must be installed in unzipped form.
-    zip_safe = False,    
+    zip_safe=False,
 )


### PR DESCRIPTION
This change makes the ZenPack incompatible with Zenoss version 3 and
earlier.

Fixes ZEN-14256.
